### PR TITLE
Fix applet not starting from a fresh install in Linux Mint 21.1

### DIFF
--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/4.0/applet.js
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/4.0/applet.js
@@ -168,7 +168,7 @@ MyApplet.prototype = {
     let configFile = Gio.file_new_for_path(this.configFilePath);
 
     if (!configFile.query_exists(null)) {
-      Util.spawnCommandLineAsync('mkdir ' + this.configFilePath, () => {
+      Util.spawnCommandLineAsync('mkdir -p ' + this.configFilePath, () => {
         this.__init(panel_height);
       });
     } else {

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
@@ -1,7 +1,7 @@
 {
     "uuid": "multicore-sys-monitor@ccadeptic23",
     "name": "Multi-Core System Monitor",
-    "version": "1.8.92",
+    "version": "1.8.93",
     "description": "Displays in realtime the cpu usage for each core/cpu and overall memory usage.",
     "multiversion": true,
     "cinnamon-version": ["2.8", "3.0", "3.2", "3.4", "3.6", "3.8", "4.0", "4.2", "4.4", "4.6"]


### PR DESCRIPTION
It looks like the applet was not able to create the `~/.cinnamon/configs` folder if it wasn't already in place.

